### PR TITLE
Reconnection-aware payload tracking

### DIFF
--- a/src/main/java/andesite/node/handler/WebSocketHandler.java
+++ b/src/main/java/andesite/node/handler/WebSocketHandler.java
@@ -372,9 +372,7 @@ public class WebSocketHandler {
                 }
                 case "clear-rcvd-ids": {
                     JsonArray ids = payload.getJsonArray("ids");
-                    for (int i = 0; i < ids.size(); i++) {
-                        rcvdIds.remove(ids.getValue(i));
-                    }
+                    ids.forEach(rcvdIds::remove);
                     break;
                 }
             }

--- a/src/main/java/andesite/node/handler/WebSocketHandler.java
+++ b/src/main/java/andesite/node/handler/WebSocketHandler.java
@@ -21,6 +21,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -123,7 +124,7 @@ public class WebSocketHandler {
         private final Context context;
         private final Long timerId;
         private final Set<Player> subscriptions = ConcurrentHashMap.newKeySet();
-        private final Set<Object> rcvdIds = ConcurrentHashMap.newKeySet();
+        private final Set<Object> rcvdIds = new HashSet<>();
         private final AndesiteEventListener listener = new AndesiteEventListener() {
             @Override
             public void onWebSocketClosed(@Nonnull NodeState state, @Nonnull String userId,


### PR DESCRIPTION
Adds supports to "rcvd" field on every incoming payload received, which caches its value on a Set.

Also adds "get-rcvd-ids" and "clear-rcvd-ids" events. "get-rcvd-ids" event replies with a "rcvd-ids" event which has all the received "rcvd" values. It supports a "clear" field which clears the local set. "clear-rcvd-ids" clears the specified ids of on the local sets and doesn't emit any event.

If the websocket is closed and event buffering is enabled, it'll emit a "rcvd-ids" of the last connection into the event buffer so reconnected clients can know what to re-send.