### PR TITLE
Update granitepy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See [CONFIGURATION.md](https://github.com/natanbc/andesite-node/blob/master/CONF
 
 - [AndeClient](https://github.com/arudiscord/andeclient) - Java 11+
 - [andesite.py](https://github.com/gieseladev/andesite.py) - Python
-- [Granitepy](https://github.com/twitch0001/granitepy) - Python
+- [Granitepy](https://github.com/MyNameBeMrRandom/granitepy) - Python
 - [discord.js-andesite](https://github.com/lolwastedjs/discord.js-andesite) - JavaScript
 - [Create your own](https://github.com/natanbc/andesite-node/blob/master/API.md)
 - Most lavalink 3.x clients should be compatible


### PR DESCRIPTION
The owner of granitepy stopped development of the library, and allowed me to pick it back up. It is now under a new repo and he is ok with changing the link in andesites description.