### PR TITLE
Fix lavalink compatibility in frameStats JSON

### DIFF
--- a/src/main/java/andesite/handler/RequestHandler.java
+++ b/src/main/java/andesite/handler/RequestHandler.java
@@ -628,8 +628,6 @@ public class RequestHandler implements AndesiteRequestHandler {
             frames.put("nulled", totalLost / players);
             frames.put("deficit", totalDeficit / players);
             root.put("frameStats", frames);
-        } else {
-            root.putNull("frameStats");
         }
         
         return root;


### PR DESCRIPTION
Currently, [lavalink will only add the JSON key if there is a number of players](https://github.com/Frederikam/Lavalink/blob/eb9ec1b824e664bba5c7fad452a1b8324d84052b/LavalinkServer/src/main/java/lavalink/server/io/StatsTask.java#L115) and not make it null; yet andesite will make it null instead of not including it at all, this breaks clients such as [Wavelink](https://github.com/PythonistaGuild/Wavelink/blob/master/wavelink/stats.py#L61). This fixes the issue. Targeted koe branch as it seems like the best place for dev stuff