### PR TITLE
Chore: Update lavaplayer to 1.3.58

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     koeVersion =          '64b28abee9'
     nettyEpollVersion =   '4.1.52.Final'
     nettyKQueueVersion =  '4.1.52.Final'
-    lavaplayerVersion =   '1.3.53'
+    lavaplayerVersion =   '1.3.58'
     lpcrossVersion =      '0.1'
     ytRotatorVersion =    '0.1.7'
     lavadspVersion =      '0.7.2'


### PR DESCRIPTION
This fixes both livestreams not working properly aswell as some issues with random YT urls.

Update is from 1.3.53 to 1.3.58. Seems to work fine to me :o 