### PR TITLE
Update Lavaplayer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     koeVersion =          '64b28abee9'
     nettyEpollVersion =   '4.1.52.Final'
     nettyKQueueVersion =  '4.1.52.Final'
-    lavaplayerVersion =   '1.3.60'
+    lavaplayerVersion =   '1.3.61'
     lpcrossVersion =      '0.1.1'
     ytRotatorVersion =    '0.1.7'
     lavadspVersion =      '0.7.4'


### PR DESCRIPTION
1.3.60 -> 1.3.61 

Fixes issues with age-gated videos not loading properly.