### PR TITLE
Fix track load failed message

### DIFF
--- a/src/main/java/andesite/handler/RestHandler.java
+++ b/src/main/java/andesite/handler/RestHandler.java
@@ -248,12 +248,12 @@ public class RestHandler {
             state.requestHandler().resolveTracks(identifier)
                     .thenAccept(json -> context.response().end(json.toBuffer()))
                     .exceptionally(e -> {
-                        if(e instanceof FriendlyException) {
+                        if(e.getCause() instanceof FriendlyException) {
                             context.response().end(
                                     new JsonObject()
                                             .put("loadType", "LOAD_FAILED")
-                                            .put("cause", RequestUtils.encodeThrowable(context, e))
-                                            .put("severity", ((FriendlyException) e).severity.name())
+                                            .put("cause", RequestUtils.encodeThrowable(context, e.getCause()))
+                                            .put("severity", ((FriendlyException) e.getCause()).severity.name())
                                             .toBuffer()
                             );
                         } else {


### PR DESCRIPTION
When a track fails to load, the error body returned is incorrect.

See https://canary.discord.com/channels/486311607400529931/539929987281715201/783242266155679775